### PR TITLE
Update gatt.js with an increased max MTU size

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -66,7 +66,7 @@ class Gatt  extends EventEmitter {
   constructor() {
     super();
 
-    this.maxMtu = 256;
+    this.maxMtu = 512;
     this._mtu = 23;
     this._preparedWriteRequest = null;
 


### PR DESCRIPTION
Max MTU from 256 to 512, enables faster filetransfer